### PR TITLE
Fix build against latest MRPT

### DIFF
--- a/3rdparty/line_descriptor/CMakeLists.txt
+++ b/3rdparty/line_descriptor/CMakeLists.txt
@@ -18,10 +18,10 @@ set(LIBRARY_OUTPUT_PATH    ${PROJECT_SOURCE_DIR}/lib)
 
 include_directories( include ${OpenCV_INCLUDE_DIRS} )
 list(APPEND LINK_LIBS ${OpenCV_LIBS} )
-file(GLOB_RECURSE all_include_files RELATIVE "${CMAKE_SOURCE_DIR}" *.h *.hpp)
+file(GLOB_RECURSE all_include_files RELATIVE "${PROJECT_SOURCE_DIR}" *.h *.hpp)
 
 link_directories(${CMAKE_SOURCE_DIR}/src/)
-file(GLOB_RECURSE all_source_files RELATIVE "${CMAKE_SOURCE_DIR}src/" *.cpp )
+file(GLOB_RECURSE all_source_files RELATIVE "${PROJECT_SOURCE_DIR}src/" *.cpp )
 
 add_custom_target( linedesc_includes DEPENDS ${all_include_files} SOURCES ${all_source_files} )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,9 @@ endif(COMMAND cmake_policy)
 link_directories(${OpenCV_LIBS_DIR})
 include_directories(${OpenCV2_INCLUDE_DIRS})
 
+# Include line_descriptor as project:
+add_subdirectory(3rdparty/line_descriptor)
+
 set(DEFAULT_HAS_MRPT ON)
 set(HAS_MRPT ${DEFAULT_HAS_MRPT} CACHE BOOL "Build the PointGrey Bumblebee2 SVO application that employs the MRPT library")
 
@@ -24,10 +27,10 @@ set(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/lib)
 
 # MRPT library (optional, only with representation purposes)
 if(HAS_MRPT)
-find_package(MRPT REQUIRED base opengl gui hwdrivers)
+find_package(MRPT REQUIRED opengl gui hwdrivers)
 set(MRPT_DONT_USE_DBG_LIBS 1) #use release libraries for linking even if "Debug" CMake build
 add_definitions(-DHAS_MRPT)
-endif(HAS_MRPT)
+endif()
 
 # YAML library
 FIND_PACKAGE(yaml-cpp REQUIRED CONFIG PATHS ${YAML_PATHS})
@@ -47,7 +50,7 @@ list(APPEND LINK_LIBS
   ${OpenCV_LIBS}
   ${Boost_LIBRARIES}
   ${YAML_CPP_LIBRARIES}
-  ${PROJECT_SOURCE_DIR}/3rdparty/line_descriptor/lib/liblinedesc.so
+  linedesc
 )
 
 # Set source files 
@@ -80,10 +83,10 @@ add_custom_target( stvo_includes DEPENDS ${all_include_files} SOURCES ${all_incl
 # Create StVO-PL library
 add_library(stvo SHARED ${SOURCEFILES})
 
-if(HAS_MRPT)
-target_link_libraries(stvo ${LINK_LIBS} ${MRPT_LIBS})
-else()
 target_link_libraries(stvo ${LINK_LIBS})
+
+if(HAS_MRPT)
+target_link_libraries(stvo ${MRPT_LIBS} ${MRPT_LIBRARIES})
 endif()
 
 # Applications

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,10 @@ project( stvo-pl )
 
 cmake_minimum_required(VERSION 2.7)
 find_package(OpenCV 3 REQUIRED)
-find_package(Boost REQUIRED COMPONENTS regex thread system filesystem)	
+find_package(Boost REQUIRED COMPONENTS regex thread system filesystem)
 
 if(COMMAND cmake_policy)
-  	cmake_policy(SET CMP0003 NEW)	
+  	cmake_policy(SET CMP0003 NEW)
 endif(COMMAND cmake_policy)
 link_directories(${OpenCV_LIBS_DIR})
 include_directories(${OpenCV2_INCLUDE_DIRS})
@@ -27,9 +27,8 @@ set(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/lib)
 
 # MRPT library (optional, only with representation purposes)
 if(HAS_MRPT)
-find_package(MRPT REQUIRED opengl gui hwdrivers)
-set(MRPT_DONT_USE_DBG_LIBS 1) #use release libraries for linking even if "Debug" CMake build
-add_definitions(-DHAS_MRPT)
+    find_package(MRPT 1.9.9 REQUIRED opengl gui hwdrivers)
+    add_definitions(-DHAS_MRPT)
 endif()
 
 # YAML library
@@ -46,14 +45,14 @@ include_directories(
 )
 
 # Set link libraries
-list(APPEND LINK_LIBS 
+list(APPEND LINK_LIBS
   ${OpenCV_LIBS}
   ${Boost_LIBRARIES}
   ${YAML_CPP_LIBRARIES}
   linedesc
 )
 
-# Set source files 
+# Set source files
 if(HAS_MRPT)
 list(APPEND SOURCEFILES
   src/sceneRepresentation.cpp
@@ -92,9 +91,3 @@ endif()
 # Applications
 add_executable       ( imagesStVO app/imagesStVO.cpp )
 target_link_libraries( imagesStVO stvo )
-
-
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -44,16 +44,21 @@ sudo apt install libyaml-cpp-dev
 ```
 
 ### MRPT (>=v1.9.9)
-In case of using the provided representation class.
-Download and install instructions can be found at: https://www.mrpt.org/
-Either:
-- (recommended) Install [from this PPA](https://launchpad.net/~joseluisblancoc/+archive/ubuntu/mrpt).
-- or build [from sources](https://github.com/mrpt/mrpt/).
+Optional: Enables the provided visualization class.
+
+1) Only for Ubuntu 16.04 Xenial: upgrade gcc. Instructions [here](https://gist.github.com/jlblancoc/99521194aba975286c80f93e47966dc5).
+2) For any Ubuntu version older than 20.04 Focal:
+```
+sudo add-apt-repository ppa:joseluisblancoc/mrpt
+sudo apt-get update
+```
+3) Everyone: Install mrpt libraries:
+```
+sudo apt-get install libmrpt-dev
+```
 
 ### Line Descriptor
 We have modified the [*line_descriptor*](https://github.com/opencv/opencv_contrib/tree/master/modules/line_descriptor) module from the [OpenCV/contrib](https://github.com/opencv/opencv_contrib) library (both BSD) which is included in the *3rdparty* folder.
-
-
 
 
 ## 2. Configuration and generation

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This code contains an algorithm to compute stereo visual odometry by using both point and line segment features.
 
-**Authors:** [Ruben Gomez-Ojeda](http://mapir.isa.uma.es/mapirwebsite/index.php/people/164-ruben-gomez) 
+**Authors:** [Ruben Gomez-Ojeda](http://mapir.isa.uma.es/mapirwebsite/index.php/people/164-ruben-gomez)
 and [David Zuñiga-Noël](http://mapir.isa.uma.es/mapirwebsite/index.php/people/270)
 and [Javier Gonzalez-Jimenez](http://mapir.isa.uma.es/mapirwebsite/index.php/people/95-javier-gonzalez-jimenez)
 
@@ -26,7 +26,7 @@ Please do not hesitate to contact the authors if you have any further questions.
 ## 1. Prerequisites and dependencies
 
 ### OpenCV 3.x.x
-It can be easily found at http://opencv.org. 
+It can be easily found at http://opencv.org.
 
 ### Eigen3
 http://eigen.tuxfamily.org
@@ -43,15 +43,12 @@ Installation on Ubuntu 16.04:
 sudo apt install libyaml-cpp-dev
 ```
 
-### MRPT
-In case of using the provided representation class. 
-Download and install instructions can be found at: http://www.mrpt.org/
-
-#### Known Issues:
-If working with the most recent versions of the MRPT library you might find some issues due to hard refactoring, for which we recommend to use this version instead (the last one we tested):
-```
-https://github.com/MRPT/mrpt/tree/0c3d605c3cbf5f2ffb8137089e43ebdae5a55de3
-```
+### MRPT (>=v1.9.9)
+In case of using the provided representation class.
+Download and install instructions can be found at: https://www.mrpt.org/
+Either:
+- (recommended) Install [from this PPA](https://launchpad.net/~joseluisblancoc/+archive/ubuntu/mrpt).
+- or build [from sources](https://github.com/mrpt/mrpt/).
 
 ### Line Descriptor
 We have modified the [*line_descriptor*](https://github.com/opencv/opencv_contrib/tree/master/modules/line_descriptor) module from the [OpenCV/contrib](https://github.com/opencv/opencv_contrib) library (both BSD) which is included in the *3rdparty* folder.
@@ -62,7 +59,7 @@ We have modified the [*line_descriptor*](https://github.com/opencv/opencv_contri
 ## 2. Configuration and generation
 A CMakeLists.txt file is included to detect external dependencies and generate the project.
 
-The project builds "imagesStVO", a customizable application where the user must introduce the inputs to the SVO algorithm, and then process the provided output. 
+The project builds "imagesStVO", a customizable application where the user must introduce the inputs to the SVO algorithm, and then process the provided output.
 
 
 
@@ -87,50 +84,3 @@ A full command would be:
 ./imagesStVO kitti/00 -c ../config/config_kitti.yaml -o 100 -s 2 -n 1000
 
 where we are processing the sequence 00 from the KITTI dataset (in our dataset folders) with the custom config file, with an offset *-c* allowing to skip the first 100 images, a parameter *-s* to consider only one every 2 images, and a parameter *-n* to only consider 1000 input pairs.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/include/sceneRepresentation.h
+++ b/include/sceneRepresentation.h
@@ -27,18 +27,21 @@ using namespace std;
 
 #include <mrpt/opengl.h>
 #include <mrpt/gui.h>
-#include <mrpt/utils/CConfigFile.h>
-#include <mrpt/utils/CConfigFileBase.h>
+#include <mrpt/config/CConfigFile.h>
+#include <mrpt/config/CConfigFileBase.h>
 #include <mrpt/maps/CPointsMap.h>
 #include <mrpt/maps/CColouredPointsMap.h>
 #include <mrpt/maps/CSimplePointsMap.h>
+#include <mrpt/img/CImage.h>
+#include <list>
 using namespace mrpt;
 using namespace mrpt::gui;
 using namespace mrpt::poses;
-using namespace mrpt::utils;
+using namespace mrpt::config;
 using namespace mrpt::math;
 using namespace mrpt::opengl;
 using namespace mrpt::maps;
+using mrpt::img::CImage;
 
 #include <opencv/cv.h>
 using namespace cv;
@@ -65,8 +68,8 @@ public:
     void initializeScene(Matrix4d x_0, bool has_gt);
 //    void initializeScene(Matrix4d x_0, Matrix4d x_0gt);
 
-    bool updateScene();
-    bool updateScene(list<PointFeature *> matched_pt, list<LineFeature *> matched_ls);
+    bool updateScene(); 
+    bool updateScene(std::list<PointFeature *> matched_pt, list<LineFeature *> matched_ls);
     void plotPointsCovariances();
     void plotLinesCovariances();
 
@@ -97,21 +100,21 @@ private:
     CPose3D getPoseXYZ(VectorXd x);
 
     CDisplayWindow3D*           win;
-    COpenGLScenePtr             theScene;
-    COpenGLViewportPtr          image, legend, help;
-    opengl::CSetOfObjectsPtr    bbObj, bbObj1, srefObj, srefObj1, gtObj, srefObjGT, elliObjL, elliObjP;
-    opengl::CEllipsoidPtr       elliObj;
-    opengl::CSetOfLinesPtr      lineObj;
-    opengl::CPointCloudPtr      pointObj;
+    COpenGLScene::Ptr             theScene;
+    COpenGLViewport::Ptr          image, legend, help;
+    opengl::CSetOfObjects::Ptr    bbObj, bbObj1, srefObj, srefObj1, gtObj, srefObjGT, elliObjL, elliObjP;
+    opengl::CEllipsoid::Ptr       elliObj;
+    opengl::CSetOfLines::Ptr      lineObj;
+    opengl::CPointCloud::Ptr      pointObj;
 
     //CPointsMapPtr pointsObj;
 
-    opengl::CFrustumPtr         frustObj, frustObj1;
-    opengl::CAxisPtr            axesObj;
+    opengl::CFrustum::Ptr         frustObj, frustObj1;
+    opengl::CAxis::Ptr            axesObj;
 
 
     float           sbb, saxis, srad, sref, sline, sfreq, szoom, selli, selev, sazim, sfrust, slinef;
-    CVectorDouble   v_aux, v_aux_, v_aux1, v_aux1_, v_auxgt, gt_aux_, v_auxgt_;
+    CVectorFixedDouble<6>  v_aux, v_aux_, v_aux1, v_aux1_, v_auxgt, gt_aux_, v_auxgt_;
     CPose3D         pose, pose_0, pose_gt, pose_ini, ellPose, pose1,  change, frustumL_, frustumR_;
     Matrix4d        x_ini;
     mrptKeyModifier kmods;

--- a/src/sceneRepresentation.cpp
+++ b/src/sceneRepresentation.cpp
@@ -137,9 +137,9 @@ void sceneRepresentation::initializeScene(Matrix4d x_0, bool has_gt){
     pose_0  = x_aux;
     pose_gt = pose_ini - change;
     x_ini   = x_0;
-    pose.getAsVector(v_aux);
-    pose1.getAsVector(v_aux1);
-    pose_gt.getAsVector(v_auxgt);
+    pose.asVector(v_aux);
+    pose1.asVector(v_aux1);
+    pose_gt.asVector(v_auxgt);
 
     // Initialize the camera object
     bbObj = opengl::stock_objects::BumblebeeCamera();
@@ -216,7 +216,7 @@ void sceneRepresentation::initializeScene(Matrix4d x_0, bool has_gt){
     // Initialize the text
     if(hasText){
         string text = "Frame: \t \t0 \nFrequency: \t0 Hz \nLines:  \t0 (0)\nPoints: \t0 (0)";
-        win->addTextMessage(0.85,0.95, text, TColorf(.0,.0,.0), 0, mrpt::opengl::MRPT_GLUT_BITMAP_HELVETICA_10 );
+        win->addTextMessage(0.85,0.95, text, mrpt::img::TColorf(.0,.0,.0), 0, mrpt::opengl::MRPT_GLUT_BITMAP_HELVETICA_10 );
     }
 
     // Initialize the covariance ellipse
@@ -269,10 +269,10 @@ bool sceneRepresentation::updateScene(){
     CPose3D x_aux(getPoseFormat(x));
     pose = pose + x_aux;
     v_aux_ = v_aux;
-    pose.getAsVector(v_aux);
+    pose.asVector(v_aux);
     if(hasTraj){
-        opengl::CSimpleLinePtr obj = opengl::CSimpleLine::Create();
-        obj->setLineCoords(v_aux_(0),v_aux_(1),v_aux_(2), v_aux(0),v_aux(1),v_aux(2));
+        opengl::CSimpleLine::Ptr obj = opengl::CSimpleLine::Create();
+        obj->setLineCoords(v_aux_[0],v_aux_[1],v_aux_[2], v_aux[0],v_aux[1],v_aux[2]);
         obj->setLineWidth(sline);
         obj->setColor(0,0,0.7);
         theScene->insert( obj );
@@ -286,7 +286,7 @@ bool sceneRepresentation::updateScene(){
 
     // Set camera pointing to the current trajectory
     if(hasCamFix)
-        win->setCameraPointingToPoint(v_aux(0),v_aux(1),v_aux(2));
+        win->setCameraPointingToPoint(v_aux[0],v_aux[1],v_aux[2]);
 
     // Update the GT camera pose
     if(hasGT){
@@ -295,21 +295,21 @@ bool sceneRepresentation::updateScene(){
         pose_gt = x_auxgt;
         v_auxgt_ = v_auxgt;
 
-        pose_gt.getAsVector(v_auxgt);
-        float y_ = v_auxgt(1);
-        float z_ = v_auxgt(2);
-        float b_ = v_auxgt(4);
-        float c_ = v_auxgt(5);
-        v_auxgt(1) =  z_;
-        v_auxgt(2) = -y_;
-        v_auxgt(4) = -c_;
-        v_auxgt(5) =  b_;
-        pose_gt = CPose3D(TPose3D(v_auxgt(0),v_auxgt(1),v_auxgt(2),v_auxgt(3),v_auxgt(4),v_auxgt(5)));
+        pose_gt.asVector(v_auxgt);
+        float y_ = v_auxgt[1];
+        float z_ = v_auxgt[2];
+        float b_ = v_auxgt[4];
+        float c_ = v_auxgt[5];
+        v_auxgt[1] =  z_;
+        v_auxgt[2] = -y_;
+        v_auxgt[4] = -c_;
+        v_auxgt[5] =  b_;
+        pose_gt = CPose3D(TPose3D(v_auxgt[0],v_auxgt[1],v_auxgt[2],v_auxgt[3],v_auxgt[4],v_auxgt[5]));
 
 
         if(hasTraj){
-            opengl::CSimpleLinePtr obj = opengl::CSimpleLine::Create();
-            obj->setLineCoords(v_auxgt_(0),v_auxgt_(1),v_auxgt_(2), v_auxgt(0),v_auxgt(1),v_auxgt(2));
+            opengl::CSimpleLine::Ptr obj = opengl::CSimpleLine::Create();
+            obj->setLineCoords(v_auxgt_[0],v_auxgt_[1],v_auxgt_[2], v_auxgt[0],v_auxgt[1],v_auxgt[2]);
             obj->setLineWidth(sline);
             obj->setColor(0,0,0);
             theScene->insert( obj );
@@ -323,10 +323,10 @@ bool sceneRepresentation::updateScene(){
         CPose3D x_aux1(getPoseFormat(xcomp));
         pose1 = pose1 + x_aux1;
         v_aux1_ = v_aux1;
-        pose1.getAsVector(v_aux1);
+        pose1.asVector(v_aux1);
         if(hasTraj){
-            opengl::CSimpleLinePtr obj = opengl::CSimpleLine::Create();
-            obj->setLineCoords(v_aux1_(0),v_aux1_(1),v_aux1_(2), v_aux1(0),v_aux1(1),v_aux1(2));
+            opengl::CSimpleLine::Ptr obj = opengl::CSimpleLine::Create();
+            obj->setLineCoords(v_aux1_[0],v_aux1_[1],v_aux1_[2], v_aux1[0],v_aux1[1],v_aux1[2]);
             obj->setLineWidth(sline);
             obj->setColor(0,0.7,0);
             theScene->insert( obj );
@@ -338,7 +338,7 @@ bool sceneRepresentation::updateScene(){
     // Update the text
     if(hasText){
         string text = "Frame: \t \t" + to_string(frame) + " \n" + "Frequency: \t" + to_string_with_precision(1000.f/time,4) + " Hz \n" + "Lines:  \t" + to_string(nLines) + " (" + to_string(nLinesH) + ") \nPoints: \t" + to_string(nPoints) + " (" + to_string(nPointsH) + ")";
-        win->addTextMessage(0.85,0.95, text, TColorf(.0,.0,.0), 0, mrpt::opengl::MRPT_GLUT_BITMAP_HELVETICA_10 );
+        win->addTextMessage(0.85,0.95, text, mrpt::img::TColorf(.0,.0,.0), 0, mrpt::opengl::MRPT_GLUT_BITMAP_HELVETICA_10 );
     }
 
     // Update the covariance
@@ -357,7 +357,7 @@ bool sceneRepresentation::updateScene(){
     lineObj->clear();
     if(hasLines){
         //plotLinesCovariances();
-        for(int i = 0; i < size(lData,2); i++)
+        for(int i = 0; i < lData.cols(); i++)
             lineObj->appendLine(lData(0,i),lData(1,i),lData(2,i), lData(3,i),lData(4,i),lData(5,i));
         lineObj->setPose(pose);
     }
@@ -366,7 +366,7 @@ bool sceneRepresentation::updateScene(){
     pointObj->clear();
     if(hasPoints){
         //plotPointsCovariances();
-        for(int i = 0; i < size(pData,2); i++)
+        for(int i = 0; i < pData.cols(); i++)
             pointObj->insertPoint(pData(0,i),pData(1,i),pData(2,i));
         pointObj->setPose(pose);
     }
@@ -404,7 +404,7 @@ bool sceneRepresentation::updateScene(){
         else if ( (key ==  97) || (key == 65) ){    // A        axes
             hasAxes   = !hasAxes;
             if(!hasAxes){
-                axesObj.clear();
+                axesObj.reset();
             }
             else{
                 axesObj = opengl::CAxis::Create();
@@ -417,8 +417,8 @@ bool sceneRepresentation::updateScene(){
         else if ( (key == 102) || (key == 70) ){    // F        frustum
             hasFrustum   = !hasFrustum;
             if(!hasFrustum){
-                frustObj.clear();
-                frustObj1.clear();
+                frustObj.reset();
+                frustObj1.reset();
             }
             else{
                 frustObj = opengl::CFrustum::Create();
@@ -436,7 +436,7 @@ bool sceneRepresentation::updateScene(){
         else if ( (key == 112) || (key == 80) ){    // P        points
             hasPoints = !hasPoints;
             if(!hasPoints){
-                elliObjP.clear();
+                elliObjP.reset();
             }
             else{
                 elliObjP = opengl::CSetOfObjects::Create();
@@ -448,7 +448,7 @@ bool sceneRepresentation::updateScene(){
         else if ( (key == 108) || (key == 76) ){    // L        lines
             hasLines  = !hasLines;
             if(!hasLines){
-                elliObjL.clear();
+                elliObjL.reset();
             }
             else{
                 elliObjL = opengl::CSetOfObjects::Create();
@@ -461,13 +461,13 @@ bool sceneRepresentation::updateScene(){
             hasText  = !hasText;
             if(!hasText){
                 string text = "";
-                win->addTextMessage(0.85,0.95, text, TColorf(1.0,1.0,1.0), 0, mrpt::opengl::MRPT_GLUT_BITMAP_HELVETICA_10 );
+                win->addTextMessage(0.85,0.95, text, mrpt::img::TColorf(1.0,1.0,1.0), 0, mrpt::opengl::MRPT_GLUT_BITMAP_HELVETICA_10 );
             }
         }
         else if ( (key ==  99) || (key == 67) ){    // C        covariance
             hasCov   = !hasCov;
             if(!hasCov){
-                elliObj.clear();
+                elliObj.reset();
             }
             else{
                 elliObj = opengl::CEllipsoid::Create();
@@ -512,10 +512,10 @@ bool sceneRepresentation::updateScene(list<PointFeature*> matched_pt, list<LineF
     CPose3D x_aux(getPoseFormat(x));
     pose = pose + x_aux;
     v_aux_ = v_aux;
-    pose.getAsVector(v_aux);
+    pose.asVector(v_aux);
     if(hasTraj){
-        opengl::CSimpleLinePtr obj = opengl::CSimpleLine::Create();
-        obj->setLineCoords(v_aux_(0),v_aux_(1),v_aux_(2), v_aux(0),v_aux(1),v_aux(2));
+        auto obj = opengl::CSimpleLine::Create();
+        obj->setLineCoords(v_aux_[0],v_aux_[1],v_aux_[2], v_aux[0],v_aux[1],v_aux[2]);
         obj->setLineWidth(sline);
         obj->setColor(0,0,0.7);
         theScene->insert( obj );
@@ -529,7 +529,7 @@ bool sceneRepresentation::updateScene(list<PointFeature*> matched_pt, list<LineF
 
     // Set camera pointing to the current trajectory
     if(hasCamFix)
-        win->setCameraPointingToPoint(v_aux(0),v_aux(1),v_aux(2));
+        win->setCameraPointingToPoint(v_aux[0],v_aux[1],v_aux[2]);
 
     // Update the GT camera pose
     if(hasGT){
@@ -538,11 +538,11 @@ bool sceneRepresentation::updateScene(list<PointFeature*> matched_pt, list<LineF
         pose_gt = x_auxgt;
         v_auxgt_ = v_auxgt;
 
-        pose_gt.getAsVector(v_auxgt);
-        float y_ = v_auxgt(1);
-        float z_ = v_auxgt(2);
-        float b_ = v_auxgt(4);
-        float c_ = v_auxgt(5);
+        pose_gt.asVector(v_auxgt);
+        float y_ = v_auxgt[1];
+        float z_ = v_auxgt[2];
+        float b_ = v_auxgt[4];
+        float c_ = v_auxgt[5];
         v_auxgt(1) =  z_;
         v_auxgt(2) = -y_;
         v_auxgt(4) = -c_;
@@ -550,8 +550,8 @@ bool sceneRepresentation::updateScene(list<PointFeature*> matched_pt, list<LineF
         pose_gt = CPose3D(v_auxgt(0),v_auxgt(1),v_auxgt(2),v_auxgt(3),v_auxgt(4),v_auxgt(5));
 
         if(hasTraj){
-            opengl::CSimpleLinePtr obj = opengl::CSimpleLine::Create();
-            obj->setLineCoords(v_auxgt_(0),v_auxgt_(1),v_auxgt_(2), v_auxgt(0),v_auxgt(1),v_auxgt(2));
+            opengl::CSimpleLine::Ptr obj = opengl::CSimpleLine::Create();
+            obj->setLineCoords(v_auxgt_[0],v_auxgt_[1],v_auxgt_[2], v_auxgt[0],v_auxgt[1],v_auxgt[2]);
             obj->setLineWidth(sline);
             obj->setColor(0,0,0);
             theScene->insert( obj );
@@ -565,10 +565,10 @@ bool sceneRepresentation::updateScene(list<PointFeature*> matched_pt, list<LineF
         CPose3D x_aux1(getPoseFormat(xcomp));
         pose1 = pose1 + x_aux1;
         v_aux1_ = v_aux1;
-        pose1.getAsVector(v_aux1);
+        pose1.asVector(v_aux1);
         if(hasTraj){
-            opengl::CSimpleLinePtr obj = opengl::CSimpleLine::Create();
-            obj->setLineCoords(v_aux1_(0),v_aux1_(1),v_aux1_(2), v_aux1(0),v_aux1(1),v_aux1(2));
+            opengl::CSimpleLine::Ptr obj = opengl::CSimpleLine::Create();
+            obj->setLineCoords(v_aux1_[0],v_aux1_[1],v_aux1_[2], v_aux1[0],v_aux1[1],v_aux1[2]);
             obj->setLineWidth(sline);
             obj->setColor(0,0.7,0);
             theScene->insert( obj );
@@ -580,7 +580,7 @@ bool sceneRepresentation::updateScene(list<PointFeature*> matched_pt, list<LineF
     // Update the text
     if(hasText){
         string text = "Frame: \t \t" + to_string(frame) + " \n" + "Frequency: \t" + to_string_with_precision(1000.f/time,4) + " Hz \n" + "Lines:  \t" + to_string(nLines) + " (" + to_string(nLinesH) + ") \nPoints: \t" + to_string(nPoints) + " (" + to_string(nPointsH) + ")";
-        win->addTextMessage(0.85,0.95, text, TColorf(.0,.0,.0), 0, mrpt::opengl::MRPT_GLUT_BITMAP_HELVETICA_10 );
+        win->addTextMessage(0.85,0.95, text, mrpt::img::TColorf(.0,.0,.0), 0, mrpt::opengl::MRPT_GLUT_BITMAP_HELVETICA_10 );
     }
 
     // Update the covariance
@@ -596,8 +596,7 @@ bool sceneRepresentation::updateScene(list<PointFeature*> matched_pt, list<LineF
         if (static_cast<size_t>(width) != img_mrpt_image.getWidth() ||
                 static_cast<size_t>(height) != img_mrpt_image.getHeight())
             image->setViewportPosition(20, 20, img_mrpt_image.getWidth(), img_mrpt_image.getHeight());
-        image->setImageView_fast( img_mrpt_image );
-        //image->setImageView( img_mrpt_image );
+        image->setImageView( std::move(img_mrpt_image) );
     }
 
     // Update the lines
@@ -666,7 +665,7 @@ bool sceneRepresentation::updateScene(list<PointFeature*> matched_pt, list<LineF
         else if ( (key ==  97) || (key == 65) ){    // A        axes
             hasAxes   = !hasAxes;
             if(!hasAxes){
-                axesObj.clear();
+                axesObj.reset();
             }
             else{
                 axesObj = opengl::CAxis::Create();
@@ -679,8 +678,8 @@ bool sceneRepresentation::updateScene(list<PointFeature*> matched_pt, list<LineF
         else if ( (key == 102) || (key == 70) ){    // F        frustum
             hasFrustum   = !hasFrustum;
             if(!hasFrustum){
-                frustObj.clear();
-                frustObj1.clear();
+                frustObj.reset();
+                frustObj1.reset();
             }
             else{
                 frustObj = opengl::CFrustum::Create();
@@ -698,7 +697,7 @@ bool sceneRepresentation::updateScene(list<PointFeature*> matched_pt, list<LineF
         else if ( (key == 112) || (key == 80) ){    // P        points
             hasPoints = !hasPoints;
             if(!hasPoints){
-                elliObjP.clear();
+                elliObjP.reset();
             }
             else{
                 elliObjP = opengl::CSetOfObjects::Create();
@@ -710,7 +709,7 @@ bool sceneRepresentation::updateScene(list<PointFeature*> matched_pt, list<LineF
         else if ( (key == 108) || (key == 76) ){    // L        lines
             hasLines  = !hasLines;
             if(!hasLines){
-                elliObjL.clear();
+                elliObjL.reset();
             }
             else{
                 elliObjL = opengl::CSetOfObjects::Create();
@@ -723,13 +722,13 @@ bool sceneRepresentation::updateScene(list<PointFeature*> matched_pt, list<LineF
             hasText  = !hasText;
             if(!hasText){
                 string text = "";
-                win->addTextMessage(0.85,0.95, text, TColorf(1.0,1.0,1.0), 0, mrpt::opengl::MRPT_GLUT_BITMAP_HELVETICA_10 );
+                win->addTextMessage(0.85,0.95, text, mrpt::img::TColorf(1.0,1.0,1.0), 0, mrpt::opengl::MRPT_GLUT_BITMAP_HELVETICA_10 );
             }
         }
         else if ( (key ==  99) || (key == 67) ){    // C        covariance
             hasCov   = !hasCov;
             if(!hasCov){
-                elliObj.clear();
+                elliObj.reset();
             }
             else{
                 elliObj = opengl::CEllipsoid::Create();
@@ -767,7 +766,7 @@ bool sceneRepresentation::updateScene(list<PointFeature*> matched_pt, list<LineF
 
 void sceneRepresentation::plotPointsCovariances(){
 
-    unsigned int nP = size(pData,2);
+    unsigned int nP = pData.cols();
     Matrix3d covAux;
 
     // Keypoints covariance ellipsoids
@@ -790,7 +789,7 @@ void sceneRepresentation::plotPointsCovariances(){
         covP_an(2,1) = covP_an(1,2);
         covP_an << covP_an * bsigmaP / (disp2*disp2);
         // Insertion of the ellipsoids
-        CEllipsoidPtr elliAux_ = opengl::CEllipsoid::Create();
+        CEllipsoid::Ptr elliAux_ = opengl::CEllipsoid::Create();
         elliAux_->setQuantiles(1.0);
         elliAux_->enableDrawSolid3D(true);
         elliAux_->setCovMatrix(getCovFormat(covP_an));
@@ -805,7 +804,7 @@ void sceneRepresentation::plotPointsCovariances(){
 
 void sceneRepresentation::plotLinesCovariances(){
 
-    unsigned int nL = size(lData,2);
+    unsigned int nL = lData.cols();
     Matrix3d covAux;
 
     // Line-segments covariance ellipsoids
@@ -830,7 +829,7 @@ void sceneRepresentation::plotLinesCovariances(){
         covP_an(2,1) = covP_an(1,2);
         covP_an << covP_an * bsigmaL / (disp2*disp2);
         // Insertion of the ellipsoids
-        CEllipsoidPtr elliAux_ = opengl::CEllipsoid::Create();
+        CEllipsoid::Ptr elliAux_ = opengl::CEllipsoid::Create();
         elliAux_->setQuantiles(1.0);
         elliAux_->enableDrawSolid3D(true);
         elliAux_->setColor(0,0.3,0);
@@ -936,7 +935,7 @@ void sceneRepresentation::setLegend(){
         if(hasComparison){
             img_legend = "../config/aux/legend_comp.png";
             img_mrpt_legend.loadFromFile(img_legend,1);
-            legend->setImageView_fast( img_mrpt_legend );
+            legend->setImageView( std::move(img_mrpt_legend) );
         }
         else
             img_mrpt_legend.loadFromFile("",1);
@@ -944,12 +943,12 @@ void sceneRepresentation::setLegend(){
     else if(hasComparison){
         img_legend = "../config/aux/legend_full.png";
         img_mrpt_legend.loadFromFile(img_legend,1);
-        legend->setImageView_fast( img_mrpt_legend );
+        legend->setImageView( std::move(img_mrpt_legend ));
     }
     else{
         img_legend = "../config/aux/legend.png";
         img_mrpt_legend.loadFromFile(img_legend,1);
-        legend->setImageView_fast( img_mrpt_legend );
+        legend->setImageView( std::move(img_mrpt_legend ));
     }
 }
 
@@ -958,7 +957,7 @@ void sceneRepresentation::setHelp(){
     help = theScene->createViewport("help");
     img_help = "../config/aux/help.png";
     img_mrpt_help.loadFromFile(img_help,1);
-    help->setImageView_fast( img_mrpt_help );
+    help->setImageView( std::move(img_mrpt_help) );
     if(hasHelp)
         help->setViewportPosition(1600, 20, 300, 376);
     else
@@ -987,7 +986,7 @@ void sceneRepresentation::setStereoCalibration(Matrix3d K_, float b_){
 
 void sceneRepresentation::setKF(){
     // Initialize the camera object (set KF with the current pose)
-    opengl::CSetOfObjectsPtr kfbb = opengl::stock_objects::BumblebeeCamera();
+    opengl::CSetOfObjects::Ptr kfbb = opengl::stock_objects::BumblebeeCamera();
     {
         kfbb->setPose( pose );
         kfbb->setScale(sbb*3);
@@ -997,7 +996,7 @@ void sceneRepresentation::setKF(){
 
 void sceneRepresentation::setKF(Matrix4d Tfw){
     // Initialize the camera object
-    opengl::CSetOfObjectsPtr kfbb = opengl::stock_objects::BumblebeeCamera();
+    opengl::CSetOfObjects::Ptr kfbb = opengl::stock_objects::BumblebeeCamera();
     {
         //CPose3D pose( getPoseFormat(Tfw) );
         kfbb->setPose( pose );
@@ -1052,6 +1051,7 @@ bool sceneRepresentation::getYPR(float &yaw, float &pitch, float &roll){
     yaw   = y;
     pitch = p;
     roll  = r;
+    return true;
 }
 
 bool sceneRepresentation::getPose(Matrix4d &T){
@@ -1062,5 +1062,6 @@ bool sceneRepresentation::getPose(Matrix4d &T){
             T(i,j) = T_(i,j);
         }
     }
+    return true;
 }
 

--- a/src/sceneRepresentation.cpp
+++ b/src/sceneRepresentation.cpp
@@ -301,7 +301,7 @@ bool sceneRepresentation::updateScene(){
         float b_ = v_auxgt(4);
         float c_ = v_auxgt(5);
         v_auxgt(1) =  z_;
-        v_auxgt(2) = -y_;        
+        v_auxgt(2) = -y_;
         v_auxgt(4) = -c_;
         v_auxgt(5) =  b_;
         pose_gt = CPose3D(TPose3D(v_auxgt(0),v_auxgt(1),v_auxgt(2),v_auxgt(3),v_auxgt(4),v_auxgt(5)));
@@ -376,7 +376,7 @@ bool sceneRepresentation::updateScene(){
     win->repaint();
 
     // Key events   -       TODO: change the trick to employ viewports
-    if(win->keyHit()){       
+    if(win->keyHit()){
         key = win->getPushedKey(&kmods);
         if(key == MRPTK_SPACE){                     // Space    Reset VO
             theScene->clear();
@@ -547,7 +547,7 @@ bool sceneRepresentation::updateScene(list<PointFeature*> matched_pt, list<LineF
         v_auxgt(2) = -y_;
         v_auxgt(4) = -c_;
         v_auxgt(5) =  b_;
-        pose_gt = TPose3D(v_auxgt(0),v_auxgt(1),v_auxgt(2),v_auxgt(3),v_auxgt(4),v_auxgt(5));
+        pose_gt = CPose3D(v_auxgt(0),v_auxgt(1),v_auxgt(2),v_auxgt(3),v_auxgt(4),v_auxgt(5));
 
         if(hasTraj){
             opengl::CSimpleLinePtr obj = opengl::CSimpleLine::Create();
@@ -790,7 +790,7 @@ void sceneRepresentation::plotPointsCovariances(){
         covP_an(2,1) = covP_an(1,2);
         covP_an << covP_an * bsigmaP / (disp2*disp2);
         // Insertion of the ellipsoids
-        CEllipsoidPtr elliAux_ = opengl::CEllipsoid::Create();        
+        CEllipsoidPtr elliAux_ = opengl::CEllipsoid::Create();
         elliAux_->setQuantiles(1.0);
         elliAux_->enableDrawSolid3D(true);
         elliAux_->setCovMatrix(getCovFormat(covP_an));

--- a/src/stereoFrameHandler.cpp
+++ b/src/stereoFrameHandler.cpp
@@ -23,6 +23,7 @@
 #include <stereoFrameHandler.h>
 
 #include "matching.h"
+#include <random>
 
 namespace StVO{
 


### PR DESCRIPTION
The PR fixes: 
* An error due to the removal of implicit ctor of mrpt::poses::CPose3D() in recent mrpt versions, and
* Another error due to a missing `#include <random>`.

Please, merge, and reflect that the latest mrpt-1.5 version can be used to build the project, instead of referencing to a now outdated commit, as done [here](https://github.com/rubengooj/pl-slam#mrpt) ;-)

Closes #14 


cc: @rubengooj , @dzunigan  